### PR TITLE
Https connection resolution with no credentials implemented for inter…

### DIFF
--- a/src/Connect/HttpConnectionResolver.cs
+++ b/src/Connect/HttpConnectionResolver.cs
@@ -111,16 +111,21 @@ namespace PipServices3.Rpc.Connect
                         correlationId, "NO_CREDENTIAL", "SSL certificates are not configured for HTTPS protocol");
                 }
 
-                if (credential.GetAsNullableString("ssl_password") == null)
+                // Sometimes when we use https we are on an internal network and do not want to have to deal with security.
+                // When we need a https connection and we don't want to pass credentials, set the value 'no_credentials_needed' in the config yml credentials section
+                if (credential.GetAsNullableString("internal_network") == null)
                 {
-                    throw new ConfigException(
-                        correlationId, "NO_SSL_PASSWORD", "SSL password is not configured in credentials");
-                }
+                    if (credential.GetAsNullableString("ssl_password") == null)
+                    {
+                        throw new ConfigException(
+                            correlationId, "NO_SSL_PASSWORD", "SSL password is not configured in credentials");
+                    }
 
-                if (credential.GetAsNullableString("ssl_pfx_file") == null)
-                {
-                    throw new ConfigException(
-                        correlationId, "NO_SSL_PFX_FILE", "SSL pfx file is not configured in credentials");
+                    if (credential.GetAsNullableString("ssl_pfx_file") == null)
+                    {
+                        throw new ConfigException(
+                            correlationId, "NO_SSL_PFX_FILE", "SSL pfx file is not configured in credentials");
+                    }
                 }
             }
         }
@@ -144,7 +149,8 @@ namespace PipServices3.Rpc.Connect
 
             if (connection.Protocol == "https")
             {
-                connection.AddSection("credential", credential);
+                connection.AddSection("credential",
+                    credential.GetAsNullableString("internal_network") == null ? credential : new CredentialParams());
             }
             else
             {

--- a/test/Connect/HttpConnectionResolverTest.cs
+++ b/test/Connect/HttpConnectionResolverTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using PipServices3.Commons.Config;
+using PipServices3.Commons.Errors;
 using Xunit;
 
 namespace PipServices3.Rpc.Connect
@@ -28,6 +29,96 @@ namespace PipServices3.Rpc.Connect
         }
 
         [Fact]
+        public void TestHttpsWithCredentialsConnectionParams()
+        {
+            var connectionResolver = new HttpConnectionResolver();
+            connectionResolver.Configure(ConfigParams.FromTuples(
+                "connection.host", "somewhere.com",
+                "connection.port", 123,
+                "connection.protocol", "https",
+                "credential.ssl_password", "ssl_password",
+                "credential.ssl_pfx_file", "ssl_pfx_file"
+            ));
+
+            var connection = connectionResolver.ResolveAsync(null).Result;
+
+            Assert.Equal("https", connection.Protocol);
+            Assert.Equal("somewhere.com", connection.Host);
+            Assert.Equal(123, connection.Port);
+            Assert.Equal("https://somewhere.com:123", connection.Uri);
+            Assert.Equal("ssl_password", connection.Get("credential.ssl_password"));
+            Assert.Equal("ssl_pfx_file", connection.Get("credential.ssl_pfx_file"));
+        }
+
+
+        /// <summary>
+        /// In this test the credential object should not be added to the connection object
+        /// So the property 'credential.internal_network' on the connection object should be null
+        /// </summary>
+        [Fact]
+        public void TestHttpsWithNoCredentialsConnectionParams()
+        {
+            var connectionResolver = new HttpConnectionResolver();
+            connectionResolver.Configure(ConfigParams.FromTuples(
+                "connection.host", "somewhere.com",
+                "connection.port", 123,
+                "connection.protocol", "https",
+                "credential.internal_network", "internal_network"
+            ));
+
+            var connection = connectionResolver.ResolveAsync(null).Result;
+
+            Assert.Equal("https", connection.Protocol);
+            Assert.Equal("somewhere.com", connection.Host);
+            Assert.Equal(123, connection.Port);
+            Assert.Equal("https://somewhere.com:123", connection.Uri);
+            Assert.Null(connection.Get("credential.internal_network"));
+        }
+
+        [Fact]
+        public async void TestHttpsWithMissingCredentialsConnectionParams()
+        {
+            var connectionResolver = new HttpConnectionResolver();
+            connectionResolver.Configure(ConfigParams.FromTuples(
+                "connection.host", "somewhere.com",
+                "connection.port", 123,
+                "connection.protocol", "https"
+            ));
+
+            var exception = await Assert.ThrowsAsync<ConfigException>(() => connectionResolver.ResolveAsync(null));
+            Assert.Equal("SSL password is not configured in credentials", exception.Message);
+
+            connectionResolver = new HttpConnectionResolver();
+            connectionResolver.Configure(ConfigParams.FromTuples(
+                "connection.host", "somewhere.com",
+                "connection.port", 123,
+                "connection.protocol", "https",
+                "credential.ssl_password", "ssl_password"
+            ));
+
+            exception = await Assert.ThrowsAsync<ConfigException>(() => connectionResolver.ResolveAsync(null));
+            Assert.Equal("SSL pfx file is not configured in credentials", exception.Message);
+
+            connectionResolver = new HttpConnectionResolver();
+            connectionResolver.Configure(ConfigParams.FromTuples(
+                "connection.host", "somewhere.com",
+                "connection.port", 123,
+                "connection.protocol", "https",
+                "credential.ssl_password", "ssl_password",
+                "credential.ssl_pfx_file", "ssl_pfx_file"
+            ));
+
+            var connection = connectionResolver.ResolveAsync(null).Result;
+
+            Assert.Equal("https", connection.Protocol);
+            Assert.Equal("somewhere.com", connection.Host);
+            Assert.Equal(123, connection.Port);
+            Assert.Equal("https://somewhere.com:123", connection.Uri);
+            Assert.Equal("ssl_password", connection.Get("credential.ssl_password"));
+            Assert.Equal("ssl_pfx_file", connection.Get("credential.ssl_pfx_file"));
+        }
+
+        [Fact]
         public void TestConnectionUri()
         {
             var connectionResolver = new HttpConnectionResolver();
@@ -42,6 +133,5 @@ namespace PipServices3.Rpc.Connect
             Assert.Equal(123, connection.Port);
             Assert.Equal("https://somewhere.com:123", connection.Uri);
         }
-    
     }
 }


### PR DESCRIPTION
PR : HTTPS connection resolution with no credentials implemented for internal networks

ISSUE :
The issue we have is that elastic search in AWS, which requires HTTPS, but no SSL credentials (for the way it's being implemented)

HTTPS connections are forced to have SSL credentials/ in the RPC project.
I've added a flag that will skip credentials when HTTPS is used.
The flag is 'credential.internal_network', this flag just has to be present and non null for this functionality to work.

Unit tests have also been added for this change.